### PR TITLE
Docstring and wrong level error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 dist: trusty
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
 
 dist: trusty
 os: linux

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,12 +1,12 @@
 Metadata-Version: 1.1
 Name: zstd
-Version: 1.3.4.4
+Version: 1.3.4.5
 Summary: Simple python bindings to Yann Collet ZSTD compression library
 Home-page: https://github.com/sergey-dryabzhinsky/python-zstd
 Author: Sergey Dryabzhinsky
 Author-email: sergey.dryabzhinsky@gmail.com
 License: BSD
-Download-URL: https://github.com/sergey-dryabzhinsky/python-zstd/archive/v1.3.4.4.tar.gz
+Download-URL: https://github.com/sergey-dryabzhinsky/python-zstd/archive/v1.3.4.5.tar.gz
 Description: Simple ZSTandarD bindings for Python
 Keywords: zstd,zstandard,compression
 Platform: POSIX

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION_STR = ".".join([str(x) for x in VERSION])
 # Package version
 PKG_VERSION = VERSION
 # Minor versions
-PKG_VERSION += ("4",)
+PKG_VERSION += ("5",)
 PKG_VERSION_STR = ".".join([str(x) for x in PKG_VERSION])
 
 ###
@@ -174,6 +174,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -120,7 +120,7 @@ static PyObject *py_zstd_uncompress(PyObject* self, PyObject *args)
 
     dest_size = (uint64_t) ZSTD_getDecompressedSize(source, source_size);
     if (dest_size == 0) {
-        PyErr_Format(PyExc_ValueError, "Input data invalid or missing content size in frame header.");
+        PyErr_Format(ZstdError, "Input data invalid or missing content size in frame header.");
         return NULL;
     }
     result = PyBytes_FromStringAndSize(NULL, dest_size);

--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -58,14 +58,19 @@ static PyObject *py_zstd_compress(PyObject* self, PyObject *args)
         return NULL;
 #endif
 
-#if ZSTD_VERSION_NUMBER >= 10304
-    /* Fast levels (zstd >= 1.3.4) */
-    if (level < ZSTD_MIN_CLEVEL) level=ZSTD_MIN_CLEVEL;
     if (0 == level) level=ZSTD_CLEVEL_DEFAULT;
-#else
-    if (level <= 0) level=ZSTD_CLEVEL_DEFAULT;
-#endif
-    if (level > ZSTD_MAX_CLEVEL) level=ZSTD_MAX_CLEVEL;
+    /* Fast levels (zstd >= 1.3.4) - [-1..-5] */
+    /* Usual levels                - [ 1..22] */
+    /* If level less than -5 or 1 - raise Error, level 0 handled before. */
+    if (level < ZSTD_MIN_CLEVEL) {
+        PyErr_Format(ZstdError, "Bad compression level - less than %d: %d", ZSTD_MIN_CLEVEL, level);
+        return NULL;
+    }
+    /* If level more than 22 - raise Error. */
+    if (level > ZSTD_MAX_CLEVEL) {
+        PyErr_Format(ZstdError, "Bad compression level - more than %d: %d", ZSTD_MAX_CLEVEL, level);
+        return NULL;
+    }
 
     dest_size = ZSTD_compressBound(source_size);
     result = PyBytes_FromStringAndSize(NULL, dest_size);
@@ -115,7 +120,7 @@ static PyObject *py_zstd_uncompress(PyObject* self, PyObject *args)
 
     dest_size = (uint64_t) ZSTD_getDecompressedSize(source, source_size);
     if (dest_size == 0) {
-        PyErr_Format(PyExc_ValueError, "input data invalid or missing content size in frame header");
+        PyErr_Format(PyExc_ValueError, "Input data invalid or missing content size in frame header.");
         return NULL;
     }
     result = PyBytes_FromStringAndSize(NULL, dest_size);
@@ -202,6 +207,7 @@ static const uint32_t hdr_size = sizeof(uint32_t);
 static PyObject *py_zstd_compress_old(PyObject* self, PyObject *args) {
 /**
  * Old format with custom header
+ * @deprecated
  */
 
     PyObject *result;
@@ -220,6 +226,7 @@ static PyObject *py_zstd_compress_old(PyObject* self, PyObject *args) {
         return NULL;
 #endif
 
+    /* This is old version function - no Error raising here. */
 #if ZSTD_VERSION_NUMBER >= 10304
     /* Fast levels (zstd >= 1.3.4) */
     if (level < ZSTD_MIN_CLEVEL) level=ZSTD_MIN_CLEVEL;
@@ -256,6 +263,7 @@ static PyObject *py_zstd_compress_old(PyObject* self, PyObject *args) {
 static PyObject *py_zstd_uncompress_old(PyObject* self, PyObject *args) {
 /**
  * Old format with custom header
+ * @deprecated
  */
 
     PyObject *result;

--- a/src/python-zstd.h
+++ b/src/python-zstd.h
@@ -56,6 +56,10 @@
 
 #ifndef ZSTD_MIN_CLEVEL
 #define ZSTD_MIN_CLEVEL     -5
+#define ZSTD_134_DOCSTR "Also supports ultra-fast levels from -5 to -1 since module compiled with ZSTD 1.3.4+."
+#else
+#define ZSTD_MIN_CLEVEL     0
+#define ZSTD_134_DOCSTR ""
 #endif
 
 #endif
@@ -79,15 +83,25 @@ static PyObject *py_zstd_uncompress_old(PyObject* self, PyObject *args);
 PyMODINIT_FUNC initzstd(void);
 #endif
 
-#define COMPRESS_DOCSTRING      "Compress string, returning the compressed data.\nRaises an exception if any error occurs."
-#define UNCOMPRESS_DOCSTRING    "Decompress string, returning the uncompressed data.\nRaises an exception if any error occurs."
-#define VERSION_DOCSTRING       "This module version as string."
-#define ZSTD_VERSION_DOCSTRING  "ZSTD library version as string."
-#define ZSTD_INT_VERSION_DOCSTRING  "ZSTD library version as integer = (major * 100*100 + minor * 100 + release)."
+#if PY_MAJOR_VERSION < 3
+#define PY_BYTESTR_TYPE "string"
+#else
+#define PY_BYTESTR_TYPE "bytes"
+#endif
+
+#define COMPRESS_DOCSTRING      "compress(string[, level]): "PY_BYTESTR_TYPE" -- Returns compressed string.\n\n\
+Optional arg level is the compression level, from 1 (fastest) to 22 (slowest). The default value is 3.\n\
+"ZSTD_134_DOCSTR"\n\nRaises an zstd.Error exception if any error occurs."
+
+#define UNCOMPRESS_DOCSTRING    "decompress("PY_BYTESTR_TYPE"): string -- Returns uncompressed string.\n\nRaises an zstd.Error exception if any error occurs."
+
+#define VERSION_DOCSTRING       "version(): string -- Returns this module version as string."
+#define ZSTD_VERSION_DOCSTRING  "ZSTD_version(): string -- Returns ZSTD library version as string."
+#define ZSTD_INT_VERSION_DOCSTRING  "ZSTD_version_number(): int -- Returns ZSTD library version as integer.\n Format of the number is: major * 100*100 + minor * 100 + release."
 
 #if PYZSTD_LEGACY > 0
-#define COMPRESS_OLD_DOCSTRING      "Compress string, old version, returning the compressed data in custom format.\nNot compatible with streaming or origin compression tools.\nRaises an exception if any error occurs."
-#define UNCOMPRESS_OLD_DOCSTRING    "Decompress string, old version, returning the uncompressed data.\nUses custom format from `compress_old` fucntion.\nNot compatible with streaming or origin compression tools.\nRaises an exception if any error occurs."
+#define COMPRESS_OLD_DOCSTRING      "compress_old(string[, level]): "PY_BYTESTR_TYPE" -- Compress string, old version, returning the compressed data.\n\nUses custom format. Not compatible with streaming or origin compression tools.\n\nRaises an exception if any error occurs.\n@deprecated"
+#define UNCOMPRESS_OLD_DOCSTRING    "decompress_old("PY_BYTESTR_TYPE"): string -- Decompress string, old version, returning the uncompressed data.\n\nUses custom format from `compress_old` fucntion.\nNot compatible with streaming or origin compression tools.\n\nRaises an exception if any error occurs.\n@deprecated"
 #endif
 
 /**************************************

--- a/src/python-zstd.h
+++ b/src/python-zstd.h
@@ -56,7 +56,7 @@
 
 #ifndef ZSTD_MIN_CLEVEL
 #define ZSTD_MIN_CLEVEL     -5
-#define ZSTD_134_DOCSTR "Also supports ultra-fast levels from -5 (fastest) to -1 (less fast) since module compiled with ZSTD 1.3.4+."
+#define ZSTD_134_DOCSTR "Also supports ultra-fast levels from -5 (fastest) to -1 (less fast) since module compiled with ZSTD 1.3.4+.\n"
 #else
 #define ZSTD_MIN_CLEVEL     0
 #define ZSTD_134_DOCSTR ""
@@ -91,7 +91,7 @@ PyMODINIT_FUNC initzstd(void);
 
 #define COMPRESS_DOCSTRING      "compress(string[, level]): "PY_BYTESTR_TYPE" -- Returns compressed string.\n\n\
 Optional arg level is the compression level, from 1 (fastest) to 22 (slowest). The default value is 3.\n\
-"ZSTD_134_DOCSTR"\n\nRaises a zstd.Error exception if any error occurs."
+"ZSTD_134_DOCSTR"\nRaises a zstd.Error exception if any error occurs."
 
 #define UNCOMPRESS_DOCSTRING    "decompress("PY_BYTESTR_TYPE"): string -- Returns uncompressed string.\n\nRaises a zstd.Error exception if any error occurs."
 

--- a/src/python-zstd.h
+++ b/src/python-zstd.h
@@ -56,7 +56,7 @@
 
 #ifndef ZSTD_MIN_CLEVEL
 #define ZSTD_MIN_CLEVEL     -5
-#define ZSTD_134_DOCSTR "Also supports ultra-fast levels from -5 to -1 since module compiled with ZSTD 1.3.4+."
+#define ZSTD_134_DOCSTR "Also supports ultra-fast levels from -5 (fastest) to -1 (less fast) since module compiled with ZSTD 1.3.4+."
 #else
 #define ZSTD_MIN_CLEVEL     0
 #define ZSTD_134_DOCSTR ""
@@ -91,17 +91,17 @@ PyMODINIT_FUNC initzstd(void);
 
 #define COMPRESS_DOCSTRING      "compress(string[, level]): "PY_BYTESTR_TYPE" -- Returns compressed string.\n\n\
 Optional arg level is the compression level, from 1 (fastest) to 22 (slowest). The default value is 3.\n\
-"ZSTD_134_DOCSTR"\n\nRaises an zstd.Error exception if any error occurs."
+"ZSTD_134_DOCSTR"\n\nRaises a zstd.Error exception if any error occurs."
 
-#define UNCOMPRESS_DOCSTRING    "decompress("PY_BYTESTR_TYPE"): string -- Returns uncompressed string.\n\nRaises an zstd.Error exception if any error occurs."
+#define UNCOMPRESS_DOCSTRING    "decompress("PY_BYTESTR_TYPE"): string -- Returns uncompressed string.\n\nRaises a zstd.Error exception if any error occurs."
 
 #define VERSION_DOCSTRING       "version(): string -- Returns this module version as string."
 #define ZSTD_VERSION_DOCSTRING  "ZSTD_version(): string -- Returns ZSTD library version as string."
 #define ZSTD_INT_VERSION_DOCSTRING  "ZSTD_version_number(): int -- Returns ZSTD library version as integer.\n Format of the number is: major * 100*100 + minor * 100 + release."
 
 #if PYZSTD_LEGACY > 0
-#define COMPRESS_OLD_DOCSTRING      "compress_old(string[, level]): "PY_BYTESTR_TYPE" -- Compress string, old version, returning the compressed data.\n\nUses custom format. Not compatible with streaming or origin compression tools.\n\nRaises an exception if any error occurs.\n@deprecated"
-#define UNCOMPRESS_OLD_DOCSTRING    "decompress_old("PY_BYTESTR_TYPE"): string -- Decompress string, old version, returning the uncompressed data.\n\nUses custom format from `compress_old` fucntion.\nNot compatible with streaming or origin compression tools.\n\nRaises an exception if any error occurs.\n@deprecated"
+#define COMPRESS_OLD_DOCSTRING      "compress_old(string[, level]): "PY_BYTESTR_TYPE" -- Compress string, old version, returning the compressed data.\n\nUses custom format. Not compatible with streaming or origin compression tools.\n\nRaises a zstd.Error exception if any error occurs.\n\n@deprecated"
+#define UNCOMPRESS_OLD_DOCSTRING    "decompress_old("PY_BYTESTR_TYPE"): string -- Decompress string, old version, returning the uncompressed data.\n\nUses custom format from `compress_old` fucntion.\nNot compatible with streaming or origin compression tools.\n\nRaises a zstd.Error exception if any error occurs.\n\n@deprecated"
 #endif
 
 /**************************************

--- a/tests/base.py
+++ b/tests/base.py
@@ -85,6 +85,9 @@ class BaseTestZSTD(unittest.TestCase):
         CDATA = zstd.compress(tDATA, -1)
         self.assertNotEqual(CDATA, zstd.compress(tDATA, 0))
 
+    def helper_compression_wrong_level(self):
+        self.assertRaises(zstd.Error, zstd.compress, tDATA, 100)
+
     def helper_compression_old_default_level(self):
         if sys.hexversion < 0x03000000:
             DATA = 'This is must be very very long string to be compressed by zstd. AAAAAAAAAAARGGHHH!!! Just hope its enough length. И немного юникода.'

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -30,6 +30,9 @@ class TestZSTD(BaseTestZSTD):
     def test_compression_negative_level_notdefault(self):
         BaseTestZSTD.helper_compression_negative_level_notdefault(self)
 
+    def test_compression_wrong_level(self):
+        BaseTestZSTD.helper_compression_wrong_level(self)
+
     def test_compression_old_default_level(self):
         if not self.PYZSTD_LEGACY:
             return raise_skip("PyZstd was build without legacy functions support")


### PR DESCRIPTION
- update functions doctrings
- raise `zstd.Error` if level argument is wrong
- add test for it

For issue #27 