### PR TITLE
Ensure tests directory is included in the source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ graft zstd/lib/common
 graft zstd/lib/compress
 graft zstd/lib/decompress
 graft zstd/lib/legacy
+graft tests
 include zstd/lib/zstd.h


### PR DESCRIPTION
Without "tests" being listed in MANIFEST.in the tests directory is not
included when the sdist target is built.  This means that the "tests"
target fails to build from source when building from PyPi distributed
sources or builds from the sdist package.