### PR TITLE
Prepare for 1.5.0.1 - missing zstd_errors.h

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ graft tests
 include LICENSE
 include README.md
 include zstd/lib/zstd.h
+include zstd/lib/zstd_errors.h

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,12 +1,12 @@
 Metadata-Version: 1.1
 Name: zstd
-Version: 1.5.0.0
+Version: 1.5.0.1
 Summary: Simple python bindings to Yann Collet ZSTD compression library
 Home-page: https://github.com/sergey-dryabzhinsky/python-zstd
 Author: Sergey Dryabzhinsky
 Author-email: sergey.dryabzhinsky@gmail.com
 License: BSD
-Download-URL: https://github.com/sergey-dryabzhinsky/python-zstd/archive/v1.5.0.0.tar.gz
+Download-URL: https://github.com/sergey-dryabzhinsky/python-zstd/archive/v1.5.0.1.tar.gz
 Description: Simple ZSTandarD bindings for Python
 Keywords: zstd,zstandard,compression
 Platform: POSIX

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION_STR = ".".join([str(x) for x in VERSION])
 # Package version
 PKG_VERSION = VERSION
 # Minor versions
-PKG_VERSION += ("0",)
+PKG_VERSION += ("1",)
 PKG_VERSION_STR = ".".join([str(x) for x in PKG_VERSION])
 
 ###


### PR DESCRIPTION
Wrong branch, but okay