### PR TITLE
Build, test, and upload wheels on Github Actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,122 @@
+name: Build wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Cancel previous runs on the same branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Prepare python
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Set up QEMU
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: 'arm64'
+
+      - name: Build source distribution with Ubuntu
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          pip install build
+          python -m build --sdist --outdir dist .
+
+      - name: Build ${{ matrix.os }} wheels and test
+        uses: joerick/cibuildwheel@v2.3.1
+        with:
+          output-dir: dist
+        env:
+          # build just supported python versions at December 2021
+          CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-* cp310-*'
+          # Skip 32-bit builds
+          CIBW_SKIP: '*-win32 *_i686'
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
+          # Only build on x86 and arm64 for linux
+          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_BEFORE_ALL_LINUX: >
+            python -m pip install --upgrade pip
+          # CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          # Building two wheels for MacOS and skipping Universal
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          # Skip testing Apple Silicon until there are GH runners
+          CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
+          CIBW_BEFORE_ALL_MACOS: >
+            python -m pip install --upgrade pip
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.14
+          CIBW_BUILD_VERBOSITY_MACOS: 0
+          CIBW_BEFORE_ALL_WINDOWS: >
+            python -m pip install --upgrade pip
+          CIBW_TEST_COMMAND: >
+            python -m unittest discover -v -s {package}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist
+
+      - name: Test for secrets access
+        id: check_secrets
+        # If a third party makes a pull request
+        # this allows automated steps below to be skipped
+        # and leave a clean PR CI run
+        shell: bash
+        run: |
+          unset HAS_SECRET
+          if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
+          echo ::set-output name=HAS_SECRET::${HAS_SECRET}
+        env:
+          SECRET: "${{ secrets.test_pypi_password }}"
+
+      - name: Install twine
+        run: pip install twine
+
+      - name: Publish distribution to PyPI
+        if: >
+         startsWith(github.event.ref, 'refs/tags') &&
+         steps.check_secrets.outputs.HAS_SECRET
+        env:
+          # If the PR/Push has secret access
+          # and PYPI_PASSWORD is in GH Secrets for this repo
+          # and this is a tag, publish to PyPI
+          TWINE_USERNAME: __token__
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+
+      - name: Publish distribution to Test PyPI
+        if: steps.check_secrets.outputs.HAS_SECRET
+        env:
+          # If the PR/Push has secret access
+          # and TEST_PYPI_PASSWORD is in GH Secrets for this repo
+          # then publish each build to test PyPI
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+          TWINE_USERNAME: __token__
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+        run: twine upload --non-interactive --skip-existing --verbose 'dist/*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 sdist
 dist
+venv
 
 .idea
 .settings

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,11 @@ if "--external" in sys.argv:
 
 
 COPT = {
-    'msvc':     [ '/Ox', '/DVERSION=\"\\\"%s\\\"\"' % PKG_VERSION_STR, ],
-    'mingw32':  [ '-O2', '-DVERSION="%s"' % PKG_VERSION_STR, ],
-    'unix':     [ '-O2', '-DVERSION="%s"' % PKG_VERSION_STR, ],
-    'clang':    [ '-O2', '-DVERSION="%s"' % PKG_VERSION_STR, ],
-    'gcc':      [ '-O2', '-DVERSION="%s"' % PKG_VERSION_STR, ]
+    'msvc':     [ '/Ox', '/DVERSION=%s' % PKG_VERSION_STR, ],
+    'mingw32':  [ '-O2', '-DVERSION=%s' % PKG_VERSION_STR, ],
+    'unix':     [ '-O2', '-DVERSION=%s' % PKG_VERSION_STR, ],
+    'clang':    [ '-O2', '-DVERSION=%s' % PKG_VERSION_STR, ],
+    'gcc':      [ '-O2', '-DVERSION=%s' % PKG_VERSION_STR, ]
 }
 
 if not SUP_EXTERNAL:

--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -32,6 +32,11 @@
 
 /* Since 3.8 it is mandatory to use proper type for # formats */
 #define PY_SSIZE_T_CLEAN
+
+/* Simplify passing strings to the various compilers*/
+#define str(x) #x
+#define xstr(x) str(x)
+
 #include <Python.h>
 #include "pythoncapi_compat.h"    // Py_SET_SIZE() for Python 3.8 and older
 
@@ -182,9 +187,9 @@ static PyObject *py_zstd_uncompress(PyObject* self, PyObject *args)
 static PyObject *py_zstd_module_version(PyObject* self, PyObject *args)
 {
 #if PY_MAJOR_VERSION >= 3
-    return PyUnicode_FromFormat("%s", VERSION);
+    return PyUnicode_FromFormat("%s", xstr(VERSION));
 #else
-    return PyString_FromFormat("%s", VERSION);
+    return PyString_FromFormat("%s", xstr(VERSION));
 #endif
 }
 


### PR DESCRIPTION
We are going to be using this zstd as a component of chia-blockchain.

I have built this Github Action to create and test wheels for all of the major supported python versions and platforms with the exception of the 32 bit version. The latter can easily be added but the proliferation of linux options is already taking about 90 minutes to complete.

Hopefully the comments are understandable and happy to add/change/answer questions.

The one issue outstanding is that this finds some sort of incompatibility on Windows and Python 3.9.9. The library seems to respond with the version number surrounded in `"` so the version test fails. 

https://github.com/Chia-Network/python-zstd/runs/4645914536?check_suite_focus=true#step:8:679
```
  test_module_version (tests.test_version.TestZstdVersion) ... FAIL
  
  ======================================================================
  FAIL: test_module_version (tests.test_version.TestZstdVersion)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "D:\a\python-zstd\python-zstd\tests\test_version.py", line 8, in test_module_version
      BaseTestZSTD.helper_version(self)
    File "D:\a\python-zstd\python-zstd\tests\base.py", line 49, in helper_version
      self.assertEqual(self.PKG_VERSION, zstd.version())
  AssertionError: '1.5.0.4' != '"1.5.0.4"'
  - 1.5.0.4
  + "1.5.0.4"
  ? +       +
  ```

I will attempt to do a bit more debugging but hope you might have additional thoughts on the root cause of that test failure.