### PR TITLE
Support setting build options via envvars, for PEP 517 compat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,10 @@ To build with Zstd legacy versions support - pass ``--legacy`` option to setup.p
 
    >>> $ python setup.py build_ext --legacy clean
 
+When using a PEP 517 builder you can use ``ZSTD_LEGACY`` environment variable instead:
+
+   >>> $ ZSTD_LEGACY=1 python -m build -w
+
 Note: Python-Zstd legacy format support removed since 1.5.0.
 If you need to convert old data - checkout 1.4.9.1 module version. Support of it disabled by default.
 To build with python-zstd legacy format support (pre 1.1.2) - pass ``--pyzstd-legacy`` option to setup.py script:
@@ -78,6 +82,10 @@ But beware! Legacy formats support state is unknown in this case.
 And if your version not equal with python-zstd - tests may not pass.
 
    >>> $ python setup.py build_ext --external clean
+
+When using a PEP 517 builder you can use ``ZSTD_EXTERNAL`` environment variable instead:
+
+   >>> $ ZSTD_EXTERNAL=1 python -m build -w
 
 If paths to header file ``zstd.h`` and libraries is uncommon - use common ``build`` params:
 --libraries --include-dirs --library-dirs.

--- a/setup.py
+++ b/setup.py
@@ -21,24 +21,26 @@ PKG_VERSION_STR = ".".join([str(x) for x in PKG_VERSION])
 # Ugly hacks, I know
 #
 
-SUP_LEGACY=0
+SUP_LEGACY="ZSTD_LEGACY" in os.environ
 if "--legacy" in sys.argv:
     # Support legacy output format functions
-    SUP_LEGACY=1
+    SUP_LEGACY=True
     sys.argv.remove("--legacy")
 
-SUP_TRACE=0
+SUP_TRACE="ZSTD_TRACE" in os.environ
 if "--debug-trace" in sys.argv:
     # Support tracing for debug
-    SUP_TRACE=1
+    SUP_TRACE=True
     sys.argv.remove("--debug-trace")
 
-SUP_EXTERNAL=0
+SUP_EXTERNAL="ZSTD_EXTERNAL" in os.environ
 ext_libraries=[]
 if "--external" in sys.argv:
     # You want use external Zstd library?
-    SUP_EXTERNAL=1
+    SUP_EXTERNAL=True
     sys.argv.remove("--external")
+
+if SUP_EXTERNAL:
     # You should add external library by option: --libraries zstd
     # And probably include paths by option: --include-dirs /usr/include/zstd
     # And probably library paths by option: --library-dirs /usr/lib/i386-linux-gnu


### PR DESCRIPTION
Make it possible to set the "legacy", "trace" and "external" options
via environment variables rather than just via command-line arguments.
This makes it possible to use them when building zstd via the modern
PEP 517 builders rather than the deprecated setup.py calls.