### PR TITLE
Fix issues compressing an empty bytestring

### DIFF
--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -150,8 +150,8 @@ static PyObject *py_zstd_uncompress(PyObject* self, PyObject *args)
         return NULL;
 #endif
 
-    dest_size = (uint64_t) ZSTD_getDecompressedSize(source, source_size);
-    if (dest_size == 0) {
+    dest_size = (uint64_t) ZSTD_getFrameContentSize(source, source_size);
+    if (dest_size == ZSTD_CONTENTSIZE_UNKNOWN || dest_size == ZSTD_CONTENTSIZE_ERROR) {
         PyErr_Format(ZstdError, "Input data invalid or missing content size in frame header.");
         return NULL;
     }

--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -103,7 +103,7 @@ static PyObject *py_zstd_compress_mt(PyObject* self, PyObject *args)
         return NULL;
     }
 
-    if (source_size > 0) {
+    if (source_size >= 0) {
         dest = PyBytes_AS_STRING(result);
 
         cctx = ZSTD_createCCtx();

--- a/tests/base.py
+++ b/tests/base.py
@@ -122,3 +122,12 @@ class BaseTestZSTD(unittest.TestCase):
         else:
             DATA = b"This is must be very very long string to be compressed by zstd. AAAAAAAAAAAAARGGHHH!!! Just hope its enough length." + " И немного юникода.".encode()
         self.assertEqual(DATA, zstd.decompress(zstd.compress(DATA, 20)))
+
+    def helper_compression_empty_string(self):
+        # https://github.com/sergey-dryabzhinsky/python-zstd/issues/80
+        # An empty string should be able to be compressed and decompressed
+        # All levels 1-20 are tested, just to be safe.
+        data = b""
+
+        for level in range(0, 20):
+            self.assertEqual(data, zstd.decompress(zstd.compress(data, level + 1)))

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -39,6 +39,9 @@ class TestZstdCompress(BaseTestZSTD):
 
     def test_compression_level20(self):
         BaseTestZSTD.helper_compression_level20(self)
+    
+    def test_compression_empty_string(self):
+        BaseTestZSTD.helper_compression_empty_string(self)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Test included and refactoring included. This fixes #80 

## Before
```
>>> zstd.compress(b"")
b"\xe4As\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'str' object cannot be interpreted as an integer"
>>> zstd.compress(b"")
b"\xe4\x80s\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'ModuleSpec' object has no attribute '_initializ"
```

## After
```
>>> zstd.compress(b"")
b'(\xb5/\xfd \x00\x01\x00\x00'
```