### PR TITLE
chore: add python 3.12 wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,6 +45,8 @@ jobs:
             group: new
           - build: cp311-*
             group: new
+          - build: cp312-*
+            group: new
           - build: pp27-*
             group: old
           - build: pp37-*
@@ -91,7 +93,7 @@ jobs:
           python -m build --sdist --outdir dist .
 
       - name: Build ${{ matrix.os.name }} wheels and test (old)
-        uses: joerick/cibuildwheel@v1.11.1
+        uses: pypa/cibuildwheel@v2.19.1
         if: matrix.cibw.group == 'old'
         with:
           output-dir: dist


### PR DESCRIPTION
> [!Warning]
> This is a work in progress. Do not merge. 

Note: by updating the action to the maintained repository, Python 3.6 or older is no longer supported. Let me know if you would be ok with dropping support as well or if you prefer sticking around with older versions of the action.

CI run here: https://github.com/jbergstroem/python-zstd/actions/runs/9612503847/job/26513295941

---

Todo

- [ ] Fix `Invalid --only='""', must be a build selector with a known platform` on Windows builds
- [ ] Rewrite action to use new version of cibuildwheel