### PR TITLE
Fix `ZSTD_check` return type doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ ZSTD_uncompress (data): string|bytes
 
   Since: 0.1
 
-ZSTD_check (data): string|bytes
+ZSTD_check (data): int
   Function, checks if input is zstd compressed data block, returns 1 if yes, 0 if no, or raises Error.
 
   Support compressed data with multiple/concatenated frames (blocks) .


### PR DESCRIPTION
It is documented to return 0 or 1 and has this implementation: https://github.com/sergey-dryabzhinsky/python-zstd/compare/v1.5.6.1...v1.5.6.2#diff-330f36564a4e9f1d2c0873632c8a96cb3ec4863e0fdb67285138c52b72989734R240