### PR TITLE
enabled support to 3.12 per GIL interpeter using multi-phase module inizialization

### DIFF
--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -486,9 +486,9 @@ static int myextension_clear(PyObject *m) {
 //Slots not supported in Python 3.4
 #if PY_MINOR_VERSION >= 5
 static PyModuleDef_Slot ZstdModuleDefSlots[] = {
-    {Py_mod_exec, (void *)init_py_zstd},
+    {Py_mod_exec, (void *)(uintptr_t)init_py_zstd},
     #if PY_MINOR_VERSION >= 12
-    {Py_mod_multiple_interpreters, (void *)Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_multiple_interpreters, (void *)(uintptr_t)Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     #endif
     {0, NULL}
 };

--- a/src/python-zstd.c
+++ b/src/python-zstd.c
@@ -486,7 +486,9 @@ static int myextension_clear(PyObject *m) {
 
 static PyModuleDef_Slot ZstdModuleDefSlots[] = {
     {Py_mod_exec, init_py_zstd},
+    #if PY_MINOR_VERSION >= 12
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    #endif
     {0, NULL}
 };
 


### PR DESCRIPTION
The project was already correctly ready to works with multiple interpeters and also with per interpeter GIL https://peps.python.org/pep-0684/, but the module was not inizialized in multi-phase making it unusable.

PyModuleDef_Slot was added in python 3.5 so minor versions will stop working, instead I added a check for multi interpeter making it compiled only for version higher or equal than python 3.12

