### PR TITLE
Update Build_wheels_for_cpython314_x86_64_u24.yml

### DIFF
--- a/.github/workflows/Build_wheels_for_cpython314_x86_64_u24.yml
+++ b/.github/workflows/Build_wheels_for_cpython314_x86_64_u24.yml
@@ -1,4 +1,4 @@
-name: Build wheels for CPython3.14 x86_64 on Ubuntu24 with GCC All warnings
+name: Build wheels for CPython3.14 x86_64 on Ubuntu16 with GCC All warnings
 
 on: [push, pull_request]
 
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: Ubuntu 24 amd64 CPython 3.14
+          - name: Ubuntu 24+16 amd64 CPython 3.14
             runs-on: ubuntu-latest
             matrix: linux
             arch: amd64
             tag_arch: x86_64
-            release: noble
+            release: xenial
             mirror: http://azure.archive.ubuntu.com/ubuntu
             #version: 1.5.6.7
             # pyver: "3.7"
@@ -27,7 +27,7 @@ jobs:
             pypkg: python3.14
             #pypkgadd: python3.13-distutils
             pyengine_tag: cp314-cp314
-            libc_tag: manylinux_2_34
+            libc_tag: manylinux_2_14
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -64,9 +64,9 @@ jobs:
           sudo mount none ./ubuntu-${{matrix.os.release}}-${{matrix.os.arch}}/proc -t proc
           sudo mount none ./ubuntu-${{matrix.os.release}}-${{matrix.os.arch}}/dev/pts -t devpts
           sudo mount none ./ubuntu-${{matrix.os.release}}-${{matrix.os.arch}}/sys -t sysfs
-          echo "# deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/python ubuntu-${{matrix.os.release}} main" > rusoft-python.list
-          echo "# deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/backports ubuntu-${{matrix.os.release}} main" > rusoft-backports.list
-          echo "# deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/packages ubuntu-${{matrix.os.release}} main" > rusoft-packages.list
+          echo " deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/python ubuntu-${{matrix.os.release}} main" > rusoft-python.list
+          echo " deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/backports ubuntu-${{matrix.os.release}} main" > rusoft-backports.list
+          echo " deb [trusted=yes] http://packages.rusoft.ru/ppa/rusoft/packages ubuntu-${{matrix.os.release}} main" > rusoft-packages.list
           echo " deb [trusted=yes] http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu ${{matrix.os.release}} main" > deadsnakes.list
           false && sudo find ./ubuntu-${{matrix.os.release}}-${{matrix.os.arch}} -iname apt
           sudo chroot ./ubuntu-${{matrix.os.release}}-${{matrix.os.arch}} /usr/bin/apt update


### PR DESCRIPTION
Use xenial amd64 to build python3.14