### PR TITLE
Update macOS intel version for build workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - name: macOS old
-            runs-on: macos-13 # x86
+            runs-on: macos-15-intel # x86
             matrix: macos
           - name: macOS Latest
             runs-on: macos-latest # arm


### PR DESCRIPTION
macos-13 is going away.  macos-15-intel is the free intel replacement.