### PR TITLE
update pp310/311 to use manylinux_2_28, cibw v3

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -359,7 +359,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_ENABLE: pypy
+          CIBW_ENABLE: pypy pypy-eol
           CIBW_BUILD: ${{ matrix.cibw.build }}
           CIBW_BUILD_VERBOSITY: 2
           # Skip 32-bit builds // NO


### PR DESCRIPTION
cibuildwheel automatically runs `manylinux-interpreters ensure` to get the not-initially-present pp310